### PR TITLE
remove "use-wheel" option as new pip no longer supports it

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -32885,7 +32885,7 @@ export CEPH_DETECT_INIT_VIRTUALENV = ${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-v
 ceph-detect-init-all: ${CEPH_DETECT_INIT_VIRTUALENV}
 
 ${CEPH_DETECT_INIT_VIRTUALENV}:
-	cd $(srcdir)/ceph-detect-init ; ../tools/setup-virtualenv.sh ${CEPH_DETECT_INIT_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
+	cd $(srcdir)/ceph-detect-init ; ../tools/setup-virtualenv.sh ${CEPH_DETECT_INIT_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install $$NO_INDEX --find-links=file://$$(pwd)/wheelhouse -e .
 
 ceph-detect-init-clean:
 	cd $(srcdir)/ceph-detect-init ; python setup.py clean ; rm -fr wheelhouse .tox build ${CEPH_DETECT_INIT_VIRTUALENV} .coverage *.egg-info
@@ -32907,7 +32907,7 @@ export CEPH_DISK_VIRTUALENV = ${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv
 ceph-disk-all: ${CEPH_DISK_VIRTUALENV}
 
 ${CEPH_DISK_VIRTUALENV}:
-	cd $(srcdir)/ceph-disk ; ../tools/setup-virtualenv.sh ${CEPH_DISK_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DISK_VIRTUALENV}/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
+	cd $(srcdir)/ceph-disk ; ../tools/setup-virtualenv.sh ${CEPH_DISK_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DISK_VIRTUALENV}/bin/pip install $$NO_INDEX --find-links=file://$$(pwd)/wheelhouse -e .
 
 ceph-disk-clean:
 	cd $(srcdir)/ceph-disk ; python setup.py clean ; rm -fr wheelhouse .tox build ${CEPH_DISK_VIRTUALENV} .coverage *.egg-info

--- a/src/ceph-detect-init/CMakeLists.txt
+++ b/src/ceph-detect-init/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(ceph-detect-init
   COMMAND
   ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh ${CMAKE_BINARY_DIR}/ceph-detect-init-virtualenv &&
-  virtualenv/bin/pip install --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-detect-init/wheelhouse -e .
+  virtualenv/bin/pip install --no-index --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-detect-init/wheelhouse -e .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-detect-init
   COMMENT "ceph-detect-init is being created")

--- a/src/ceph-detect-init/Makefile.am
+++ b/src/ceph-detect-init/Makefile.am
@@ -59,7 +59,7 @@ export CEPH_DETECT_INIT_VIRTUALENV = ${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-v
 ceph-detect-init-all: ${CEPH_DETECT_INIT_VIRTUALENV}
 
 ${CEPH_DETECT_INIT_VIRTUALENV}:
-	cd $(srcdir)/ceph-detect-init ; ../tools/setup-virtualenv.sh ${CEPH_DETECT_INIT_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
+	cd $(srcdir)/ceph-detect-init ; ../tools/setup-virtualenv.sh ${CEPH_DETECT_INIT_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install $$NO_INDEX --find-links=file://$$(pwd)/wheelhouse -e .
 
 ceph-detect-init-clean:
 	cd $(srcdir)/ceph-detect-init ; python setup.py clean ; rm -fr wheelhouse .tox build ${CEPH_DETECT_INIT_VIRTUALENV} .coverage *.egg-info

--- a/src/ceph-detect-init/tox.ini
+++ b/src/ceph-detect-init/tox.ini
@@ -10,7 +10,6 @@ setenv = VIRTUAL_ENV={envdir}
 usedevelop = true
 deps =
   {env:NO_INDEX:}
-  --use-wheel
   --find-links=file://{toxinidir}/wheelhouse
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt

--- a/src/ceph-disk/CMakeLists.txt
+++ b/src/ceph-disk/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(ceph-disk
   COMMAND
   ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh ${CMAKE_BINARY_DIR}/ceph-disk-virtualenv &&
-  virtualenv/bin/pip install --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-disk/wheelhouse -e .
+  virtualenv/bin/pip install --no-index --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-disk/wheelhouse -e .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-disk
   COMMENT "ceph-disk is being created")

--- a/src/ceph-disk/Makefile.am
+++ b/src/ceph-disk/Makefile.am
@@ -35,7 +35,7 @@ export CEPH_DISK_VIRTUALENV = ${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv
 ceph-disk-all: ${CEPH_DISK_VIRTUALENV}
 
 ${CEPH_DISK_VIRTUALENV}:
-	cd $(srcdir)/ceph-disk ; ../tools/setup-virtualenv.sh ${CEPH_DISK_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DISK_VIRTUALENV}/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
+	cd $(srcdir)/ceph-disk ; ../tools/setup-virtualenv.sh ${CEPH_DISK_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DISK_VIRTUALENV}/bin/pip install $$NO_INDEX --find-links=file://$$(pwd)/wheelhouse -e .
 
 ceph-disk-clean:
 	cd $(srcdir)/ceph-disk ; python setup.py clean ; rm -fr wheelhouse .tox build ${CEPH_DISK_VIRTUALENV} .coverage *.egg-info

--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -8,7 +8,6 @@ setenv =
 usedevelop = true
 deps =
   {env:NO_INDEX:}
-  --use-wheel
   --find-links=file://{toxinidir}/wheelhouse
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -27,7 +27,7 @@ if test -d wheelhouse ; then
     export NO_INDEX=--no-index
 fi
 
-pip --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9'
+pip --log $DIR/log.txt install $NO_INDEX --find-links=file://$(pwd)/wheelhouse 'tox >=1.9'
 if test -f requirements.txt ; then
-    pip --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse -r requirements.txt
+    pip --log $DIR/log.txt install $NO_INDEX --find-links=file://$(pwd)/wheelhouse -r requirements.txt
 fi


### PR DESCRIPTION
--use-wheel was deprecated in favor of --only-binary in pip v7.0.0. and
--use-wheel was removed in a recent release of pip. but some packages
are source packages, so we cannot simply replace use-wheel with
only-binary. so a simpler approach is to drop --use-wheel option, as pip
respects --find-links, and will find the required package from the
wheelhouse.

Based on CEPH commit a80cce4ba6afee921a7c6adce802c91e30f8c0a9
https://github.com/ceph/ceph/pull/21159/commits/a80cce4ba6afee921a7c6adce802c91e30f8c0a9

cherry-picked from internal commit 59abda6697aa95e8f86be7f193987077f8c9e972
StoryBoard:
“Various backports to core openstack components to pick up fixes”
https://storyboard.openstack.org/#!/story/2003407

Testing:
Verified that build succeeds and there is no longer pip warnings similar to;
"no such option: --use-wheel"
