### PR TITLE
Fix aclocal 'too many loops' issue

### DIFF
--- a/m4/ax_require_defined.m4
+++ b/m4/ax_require_defined.m4
@@ -1,0 +1,37 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
+  m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])
+])dnl AX_REQUIRE_DEFINED


### PR DESCRIPTION
after adding autoconf-archive-2017.03.21-1.el7.noarch.rpm in system,
building ceph package will meet
"aclocal: error: too many loops"
autoconf-archive upgrade ax_cxx_compile_stdcxx_11.m4 to serial 18 and
need ax_require_defined.m4, adding "m4/ax_require_defined.m4" will solve
this issue.

Signed-off-by: Sun Austin <austin.sun@intel.com>