### PR TITLE
Keep Ceph up when locking a 1 node configuration

### DIFF
--- a/wrs/ceph.sh
+++ b/wrs/ceph.sh
@@ -42,6 +42,12 @@ stop ()
 {
     if [[ "$nodetype" == "controller" ]] || [[ "$nodetype" == "storage" ]]
     then
+        if [[ "$system_type" == "All-in-one" ]] && [[ "$system_mode" == "simplex" ]]
+        then
+            logecho "Ceph services will continue to run on node"
+            exit 0
+        fi
+
         logecho "Stopping ceph services..."
 
         if [ -f ${CEPH_FILE} ]


### PR DESCRIPTION
On 1 node configration we need ceph to be operational when
node is locked otherwise sysinv will give errors when trying
to configure it.

Implements: containerization-2002844-CEPH-persistent-storage-backend-for-Kubernetes
Story: 2002844
Task: 26877
Signed-off-by: Ovidiu Poncea <Ovidiu.Poncea@windriver.com>