### PR TITLE
Update ceph initialization code to work with SM and 2 node configuration

### DIFF
--- a/ceph.spec
+++ b/ceph.spec
@@ -954,7 +954,7 @@ install -m 750 wrs/ceph.sh %{buildroot}%{_sysconfdir}/services.d/controller/
 install -m 750 wrs/ceph.sh %{buildroot}%{_sysconfdir}/services.d/storage/
 install -m 750 wrs/ceph-rest-api %{buildroot}%{_initrddir}/
 install -m 750 wrs/ceph.conf.pmon %{buildroot}%{_sysconfdir}/ceph/
-install -m 750 wrs/ceph_pmon_wrapper.sh %{buildroot}%{_sysconfdir}/ceph/
+install -m 750 wrs/ceph-init-wrapper.sh %{buildroot}/%{_initrddir}/ceph-init-wrapper
 install -m 640 wrs/ceph.conf %{buildroot}%{_sysconfdir}/ceph/
 install -m 700 wrs/ceph-manage-journal.py %{buildroot}/usr/sbin/ceph-manage-journal
 install -m 700 wrs/osd-wait-status.py %{buildroot}/usr/sbin/osd-wait-status
@@ -996,8 +996,8 @@ rm -rf %{buildroot}
 %if %{with tis}
 %{_initrddir}/ceph
 %{_initrddir}/ceph-rest-api
+%{_initrddir}/ceph-init-wrapper
 %{_sysconfdir}/ceph/ceph.conf.pmon
-%{_sysconfdir}/ceph/ceph_pmon_wrapper.sh
 %config(noreplace) %{_sysconfdir}/ceph/ceph.conf
 %{_sysconfdir}/services.d/*
 %{_sbindir}/ceph-manage-journal

--- a/wrs/ceph-init-wrapper.sh
+++ b/wrs/ceph-init-wrapper.sh
@@ -35,6 +35,7 @@
 #
 
 source /usr/bin/tsconfig
+source /etc/platform/platform.conf
 
 CEPH_SCRIPT="/etc/init.d/ceph"
 CEPH_FILE="$VOLATILE_PATH/.ceph_started"
@@ -64,6 +65,14 @@ WAIT_FOR_CMD=1
 
 RC=0
 
+args=("$@")
+
+if [ ! -z $ARGS ]
+then
+    IFS=";" read -r -a new_args <<< "$ARGS"
+    args+=("${new_args[@]}")
+fi
+
 wait_for_status ()
 {
     timeout=$GET_STATUS_TIMEOUT  # wait for status no more than $timeout seconds
@@ -84,12 +93,18 @@ start ()
     if [ -f ${CEPH_FILE} ]
     then
         wait_for_status
-        ${CEPH_SCRIPT} start
+        ${CEPH_SCRIPT} start $1
         RC=$?
     else
         # Ceph is not running on this node, return success
         exit 0
     fi
+}
+
+stop ()
+{
+    wait_for_status
+    ${CEPH_SCRIPT} stop $1
 }
 
 restart ()
@@ -98,7 +113,7 @@ restart ()
     then
         wait_for_status
         touch $CEPH_RESTARTING_FILE
-        ${CEPH_SCRIPT} restart
+        ${CEPH_SCRIPT} restart $1
         rm -f $CEPH_RESTARTING_FILE
     else
         # Ceph is not running on this node, return success
@@ -162,8 +177,21 @@ log_and_kill_hung_procs ()
     done
 }
 
+
 status ()
 {
+    if [[ "$system_type" == "All-in-one" ]] && [[ "$system_mode" != "simplex" ]] && [[ "$1" == "osd" ]]
+    then
+        timeout 20 ceph -s
+        if [ "$?" -ne 0 ]
+        then
+            # Ceph cluster is not accessible. Don't panik, controller swact
+	    # may be in progress.
+	    wlog "-" INFO "Ceph is down, ignoring OSD status."
+	    exit 0
+        fi
+    fi
+
     if [ -f ${CEPH_RESTARTING_FILE} ]
     then
         # Ceph is restarting, we don't report state changes on the first pass
@@ -175,7 +203,7 @@ status ()
         # Make sure the script does not 'exit' between here and the 'rm -f' below
         # or the checkpoint file will be left behind    
         touch -f ${CEPH_GET_STATUS_FILE}
-        result=`${CEPH_SCRIPT} status`
+        result=`${CEPH_SCRIPT} status $1`
         RC=$?
         if [ "$RC" -ne 0 ]; then
             erred_procs=`echo "$result" | sort | uniq | awk ' /not running|dead|failed/ {printf "%s ", $1}' | sed 's/://g' | sed 's/, $//g'`
@@ -183,6 +211,11 @@ status ()
             blocked_ops_procs=`echo "$result" | sort | uniq | awk ' /blocked ops/ {printf "%s ", $1}' | sed 's/://g' | sed 's/, $//g'`
             invalid=0
             host=`hostname`
+            if [[ "$system_type" == "All-in-one" ]] && [[ "$system_mode" != "simplex" ]]
+            then
+                # On 2 node configuration we have a floating monitor
+                host="controller"
+            fi
             for i in $(echo $erred_procs $hung_procs)
             do
                if [[ "$i" =~ osd.?[0-9]?[0-9]|mon.$host ]]; then
@@ -214,11 +247,30 @@ status ()
                 done
                 echo "$text" | tr -d '\n' > $CEPH_STATUS_FAILURE_TEXT_FILE
             else
-               echo "$host: '${CEPH_SCRIPT} status' result contains invalid process names: $erred_procs"
-               echo "undetermined_osd" > $CEPH_STATUS_FAILURE_TEXT_FILE
+               echo "$host: '${CEPH_SCRIPT} status $1' result contains invalid process names: $erred_procs"
+               echo "Undetermined osd or monitor id" > $CEPH_STATUS_FAILURE_TEXT_FILE
             fi
         fi
+
         rm -f ${CEPH_GET_STATUS_FILE}
+
+        if [[ $RC == 0 ]] && [[ "$1" == "mon" ]] && [[ "$system_type" == "All-in-one" ]] && [[ "$system_mode" != "simplex" ]]
+        then
+            # SM needs exit code != 0 from 'status mon' argument of the init script on
+            # standby controller otherwise it thinks that the monitor is running and
+            # tries to stop it.
+            # '/etc/init.d/ceph status mon' checks the status of monitors configured in
+            # /etc/ceph/ceph.conf and if it should be running on current host.
+            # If it should not be running it just exits with code 0. This is what
+            # happens on the standby controller.
+            # When floating monitor is running on active controller /var/lib/ceph/mon of
+            # standby is not mounted (Ceph monitor partition is DRBD synced).
+            ls "/var/lib/ceph/mon/ceph-controller" > /dev/null 2>&1
+            if [ "$?" -ne 0 ]
+            then
+               exit 3
+            fi
+        fi
     else
         # Ceph is not running on this node, return success
         exit 0
@@ -226,18 +278,21 @@ status ()
 }
 
 
-case "$1" in
+case "${args[0]}" in
     start)
-        start
+        start ${args[1]}
+        ;;
+    stop)
+        stop ${args[1]}
         ;;
     restart)
-        restart
+        restart ${args[1]}
         ;;
     status)
-        status
+        status ${args[1]}
         ;;
     *)
-        echo "Usage: $0 {start|restart|status}"
+        echo "Usage: $0 {start|stop|restart|status} [{mon|osd|osd.<number>|mon.<hostname>}]"
         exit 1
         ;;
 esac

--- a/wrs/ceph.conf.pmon
+++ b/wrs/ceph.conf.pmon
@@ -1,6 +1,6 @@
 [process]
 process  = ceph
-script   = /etc/ceph/ceph_pmon_wrapper.sh
+script   = /etc/init.d/ceph-init-wrapper.sh
 
 style    = lsb
 severity = major          ; minor, major, critical


### PR DESCRIPTION
This commit adapts ceph_pmon_wrapper script to work with SM. It adds
possibility to use environment variables as arguments to the script
and renames the script so that it can be installed in /etc/init.d.

SM can pass only a single CLI arguments to init scripts (usually
'start', 'stop' and 'status') yet it can pass any environment variables
to the script. In this commit we update ceph's init wrapper to take
and environment variable "ARGS" and append it to the list of
arguments. E.g. passing ARGS=mon when the script is called
with '/etc/init.d/ceph-init-wrapper start' is equivalent to
/etc/init.d/ceph-init-wrapper start mon'.

No changes to the upstream Ceph code are done.