### PR TITLE
Fix a bug that when ceph process got killed it was not recreated

### DIFF
--- a/wrs/ceph.conf.pmon
+++ b/wrs/ceph.conf.pmon
@@ -1,6 +1,6 @@
 [process]
 process  = ceph
-script   = /etc/init.d/ceph-init-wrapper.sh
+script   = /etc/init.d/ceph-init-wrapper
 
 style    = lsb
 severity = major          ; minor, major, critical


### PR DESCRIPTION
The root cause of the problem is that the ceph recovery
script is installed in /etc/init.d as ceph-init-wrapper not
ceph-init-wrapper.sh but in the ceph.conf.pmon file the script
is set to /etc/init.d/ceph-init-wrapper.sh.

Closes-Bug: 1807444