### PR TITLE
add osd-wait-status program in RPM package

### DIFF
--- a/ceph.spec
+++ b/ceph.spec
@@ -1462,6 +1462,7 @@ fi
 %{_sbindir}/ceph-disk-udev
 %if %{with tis}
 %{_sbindir}/ceph-manage-journal
+%{_sbindir}/osd-wait-status
 %endif
 %{_libexecdir}/ceph/ceph-osd-prestart.sh
 %dir %{_udevrulesdir}


### PR DESCRIPTION
osd-wait-status is used by ceph-manage-journal. It needs
to be built into final program PRM package.

Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>