### PR TITLE
Ceph on Standard: Enable MTC management of Ceph proceses on worker nodes

### DIFF
--- a/ceph.spec
+++ b/ceph.spec
@@ -946,12 +946,14 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rgw
 %if %{with tis}
 install -d -m 750 %{buildroot}%{_sysconfdir}/services.d/controller
 install -d -m 750 %{buildroot}%{_sysconfdir}/services.d/storage
+install -d -m 750 %{buildroot}%{_sysconfdir}/services.d/worker
 mkdir -p %{buildroot}%{_initrddir}
 mkdir -p %{buildroot}%{_sysconfdir}/ceph
 mkdir -p %{buildroot}%{_unitdir}
 
 install -m 750 wrs/ceph.sh %{buildroot}%{_sysconfdir}/services.d/controller/
 install -m 750 wrs/ceph.sh %{buildroot}%{_sysconfdir}/services.d/storage/
+install -m 750 wrs/ceph.sh %{buildroot}%{_sysconfdir}/services.d/worker/
 install -m 750 wrs/ceph-rest-api %{buildroot}%{_initrddir}/
 install -m 750 wrs/ceph.conf.pmon %{buildroot}%{_sysconfdir}/ceph/
 install -m 750 wrs/ceph-init-wrapper.sh %{buildroot}/%{_initrddir}/ceph-init-wrapper

--- a/wrs/ceph.sh
+++ b/wrs/ceph.sh
@@ -22,45 +22,33 @@ logecho ()
 
 start ()
 {
-    if [[ "$nodetype" == "controller" ]] || [[ "$nodetype" == "storage" ]]
+    logecho "Starting ceph services..."
+    ${INITDIR}/ceph start >> ${LOGFILE} 2>&1
+    RC=$?
+    
+    if [ ! -f ${CEPH_FILE} ]
     then
-        logecho "Starting ceph services..."
-        ${INITDIR}/ceph start >> ${LOGFILE} 2>&1
-        RC=$?
-
-        if [ ! -f ${CEPH_FILE} ]
-        then
-            touch ${CEPH_FILE}
-        fi
-    else
-        logecho "No ceph services on ${nodetype} node"
-        exit 0
+        touch ${CEPH_FILE}
     fi
 }
 
 stop ()
 {
-    if [[ "$nodetype" == "controller" ]] || [[ "$nodetype" == "storage" ]]
+    if [[ "$system_type" == "All-in-one" ]] && [[ "$system_mode" == "simplex" ]]
     then
-        if [[ "$system_type" == "All-in-one" ]] && [[ "$system_mode" == "simplex" ]]
-        then
-            logecho "Ceph services will continue to run on node"
-            exit 0
-        fi
-
-        logecho "Stopping ceph services..."
-
-        if [ -f ${CEPH_FILE} ]
-        then
-            rm -f ${CEPH_FILE}
-        fi
-
-        ${INITDIR}/ceph stop >> ${LOGFILE} 2>&1
-        RC=$?
-    else
-        logecho "No ceph services on ${nodetype} node"
+        logecho "Ceph services will continue to run on node"
         exit 0
     fi
+    
+    logecho "Stopping ceph services..."
+    
+    if [ -f ${CEPH_FILE} ]
+    then
+        rm -f ${CEPH_FILE}
+    fi
+    
+    ${INITDIR}/ceph stop >> ${LOGFILE} 2>&1
+    RC=$?
 }
 
 RC=0


### PR DESCRIPTION
Worker nodes may now have a ceph monitor enabled, so remove checks
preventing it and make sure that ceph.sh is present in /etc/system.d/worker/.

mplements: containerization-2002844-CEPH-persistent-storage-backend-for-Kubernetes
Story: 2002844
Task: 28723