### PR TITLE
radosgw: use ceph-conf to get configuration values

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -86,7 +86,7 @@ case "$1" in
                 user="$DEFAULT_USER"
             fi
 
-            log_file=`$RADOSGW -n $name --show-config-value log_file`
+            log_file=`ceph-conf -n $name --show-config-value log_file`
             if [ -n "$log_file" ]; then
                 if [ ! -e "$log_file" ]; then
                     touch "$log_file"
@@ -123,7 +123,7 @@ case "$1" in
         timeout=0
         for name in $dlist
         do
-          t=`$RADOSGW -n $name --show-config-value rgw_exit_timeout_secs`
+          t=`ceph-conf -n $name --show-config-value rgw_exit_timeout_secs`
           if [ $t -gt $timeout ]; then timeout=$t; fi
         done
 


### PR DESCRIPTION
Init script is trying to retrieve log_file and rgw_exit_timeout_secs
configuration values but it's using "radosgw" instead of "ceph-conf"
which causes it to hang if the cluster is not up.

Replace $RADOSGW with ceph-conf.

(radosgw does not even support "--show-config-value" option)