### PR TITLE
mgr/restful: unknown request synchronization issue

### DIFF
--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -365,7 +365,8 @@ class Module(MgrModule):
             if tag == 'seq':
                 return
 
-            request = [x for x in self.requests if x.is_running(tag)]
+            with self.requests_lock:
+                request = [x for x in self.requests if x.is_running(tag)]
             if len(request) != 1:
                 self.log.warn("Unknown request '%s'" % str(tag))
                 return
@@ -588,8 +589,8 @@ class Module(MgrModule):
 
 
     def submit_request(self, _request, **kwargs):
-        request = CommandsRequest(_request)
         with self.requests_lock:
+            request = CommandsRequest(_request)
             self.requests.append(request)
         if kwargs.get('wait', 0):
             while not request.is_finished():


### PR DESCRIPTION
When running stress test against mgr/restful REST API endpoint
some requests hang and ceph-mgr restful logs: "Unknown request"

Module.requests is protected by a  threading RLock() but
there are two places where it is used without acquiring
the lock:

1. when a notification is received from ceph-mgr Module._notify()
   uses list comprehension to find the request with a matching
   tag.

2. when a new request is sent to ceph-mgr by Module.submit_request()
   the CommandRequest.__init__() calls send_command(). If ceph-mgr
   sends back a notification before the request is added to
   Module.requests this triggers "Unknown request".