### PR TITLE
Update verbose rados & rbd exceptions messages

### DIFF
--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -352,9 +352,9 @@ class Error(Exception):
         return (self.__class__, (self.message, self.errno))
 
 class InvalidArgumentError(Error):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(InvalidArgumentError, self).__init__(
-            ("RADOS Invalid Argument error (%s)" % msg))
+            ("RADOS Invalid Argument error (%s)" % msg), errno=errno)
 
 
 class OSError(Error):
@@ -363,114 +363,114 @@ class OSError(Error):
 
 class InterruptedOrTimeoutError(OSError):
     """ `InterruptedOrTimeoutError` class, derived from `OSError` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(InterruptedOrTimeoutError, self).__init__(
-            ("RADOS Interrupted or Timeout error (%s)" % msg))
+            ("RADOS Interrupted or Timeout error (%s)" % msg), errno=errno)
 
 
 class PermissionError(OSError):
     """ `PermissionError` class, derived from `OSError` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(PermissionError, self).__init__(
-            ("RADOS Permission error (%s)" % msg))
+            ("RADOS Permission error (%s)" % msg), errno=errno)
 
 
 class PermissionDeniedError(OSError):
     """ deal with EACCES related. """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(PermissionDeniedError, self).__init__(
-                ("RADOS Permission Denied error (%s)" % msg))
+                ("RADOS Permission Denied error (%s)" % msg), errno=errno)
 
 
 class ObjectNotFound(OSError):
     """ `ObjectNotFound` class, derived from `OSError` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ObjectNotFound, self).__init__(
-                ("RADOS Object Not Found error (%s)" % msg))
+                ("RADOS Object Not Found error (%s)" % msg), errno=errno)
 
 
 class NoData(OSError):
     """ `NoData` class, derived from `OSError` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(NoData, self).__init__(
-                ("RADOS No Data error (%s)" % msg))
+                ("RADOS No Data error (%s)" % msg), errno=errno)
 
 
 class ObjectExists(OSError):
     """ `ObjectExists` class, derived from `OSError` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ObjectExists, self).__init__(
-                ("RADOS Object Exists error (%s)" % msg))
+                ("RADOS Object Exists error (%s)" % msg), errno=errno)
 
 
 class ObjectBusy(OSError):
     """ `ObjectBusy` class, derived from `IOError` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ObjectBusy, self).__init__(
-                ("RADOS Object Busy error (%s)" % msg))
+                ("RADOS Object Busy error (%s)" % msg), errno=errno)
 
 
 class IOError(OSError):
     """ `ObjectBusy` class, derived from `OSError` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(IOError, self).__init__(
-                ("RADOS I/O error (%s)" % msg))
+                ("RADOS I/O error (%s)" % msg), errno=errno)
 
 
 class NoSpace(OSError):
     """ `NoSpace` class, derived from `OSError` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(NoSpace, self).__init__(
-                ("RADOS No Space error (%s)" % msg))
+                ("RADOS No Space error (%s)" % msg), errno=errno)
 
 
 class RadosStateError(Error):
     """ `RadosStateError` class, derived from `Error` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(RadosStateError, self).__init__(
-                ("RADOS Rados State error (%s)" % msg))
+                ("RADOS Rados State error (%s)" % msg), errno=errno)
 
 
 class IoctxStateError(Error):
     """ `IoctxStateError` class, derived from `Error` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(IoctxStateError, self).__init__(
-                ("RADOS Ioctx State error (%s)" % msg))
+                ("RADOS Ioctx State error (%s)" % msg), errno=errno)
 
 
 class ObjectStateError(Error):
     """ `ObjectStateError` class, derived from `Error` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ObjectStateError, self).__init__(
-                ("RADOS Object State error (%s)" % msg))
+                ("RADOS Object State error (%s)" % msg), errno=errno)
 
 
 class LogicError(Error):
     """ `` class, derived from `Error` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(LogicError, self).__init__(
-            ("RADOS Logic error (%s)" % msg))
+            ("RADOS Logic error (%s)" % msg), errno=errno)
 
 
 class TimedOut(OSError):
     """ `TimedOut` class, derived from `OSError` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(TimedOut, self).__init__(
-                ("RADOS Timed Out error (%s)" % msg))
+                ("RADOS Timed Out error (%s)" % msg), errno=errno)
 
 
 class InProgress(Exception):
     """ `InProgress` class, derived from `Error` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(InProgress, self).__init__(
-                ("RADOS In Progress error (%s)" %msg))
+                ("RADOS In Progress error (%s)" % msg), errno=errno)
 
 
 class IsConnected(Error):
     """ `IsConnected` class, derived from `Error` """
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(IsConnected, self).__init__(
-                ("RADOS Is Connected error (%s)" %msg))
+                ("RADOS Is Connected error (%s)" % msg), errno=errno)
 
 
 IF UNAME_SYSNAME == "FreeBSD":

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -540,27 +540,27 @@ class OSError(Error):
         return (self.__class__, (self.message, self.errno))
 
 class PermissionError(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(PermissionError, self).__init__(
-                ("RBD permission error (%s)" % msg))
+                ("RBD permission error (%s)" % msg), errno=errno)
 
 
 class ImageNotFound(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ImageNotFound, self).__init__(
-                ("RBD image not found (%s)" % msg))
+                ("RBD image not found (%s)" % msg), errno=errno)
 
 
 class ObjectNotFound(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ObjectNotFound, self).__init__(
-                ("RBD object not found (%s)" % msg))
+                ("RBD object not found (%s)" % msg), errno=errno)
 
 
 class ImageExists(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ImageExists, self).__init__(
-                ("RBD image already exists (%s)" %msg))
+                ("RBD image already exists (%s)" % msg), errno=errno)
 
 
 class ObjectExists(OSError):
@@ -568,82 +568,82 @@ class ObjectExists(OSError):
 
 
 class IOError(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(IOError, self).__init__(
-                ("RBD I/O error (%s)" %msg))
+                ("RBD I/O error (%s)" %msg), errno=errno)
 
 
 class NoSpace(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(NoSpace, self).__init__(
                 ("RBD insufficient space available (%s)" %
-                 msg))
+                 msg), errno=errno)
 
 
 class IncompleteWriteError(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(IncompleteWriteError, self).__init__(
-               ("RBD incomplete write error (%s)" % msg))
+               ("RBD incomplete write error (%s)" % msg), errno=errno)
 
 
 class InvalidArgument(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(InvalidArgument, self).__init__(
-                ("RBD invalid argument (%s)" % msg))
+                ("RBD invalid argument (%s)" % msg), errno=errno)
 
 
 class LogicError(Error):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(LogicError, self).__init__(
-                ("RBD logic error (%s)" % msg))
+                ("RBD logic error (%s)" % msg), errno=errno)
 
 
 class ReadOnlyImage(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ReadOnlyImage, self).__init__(
-                ("RBD read-only image (%s)" % msg))
+                ("RBD read-only image (%s)" % msg), errno=errno)
 
 
 class ImageBusy(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ImageBusy, self).__init__(
-                "RBD image is busy")
+                ("RBD image is busy (%s)" % msg), errno=errno)
 
 
 class ImageHasSnapshots(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ImageHasSnapshots, self).__init__(
-                ("RBD image has snapshots (%s)" % msg))
+                ("RBD image has snapshots (%s)" % msg), errno=errno)
 
 
 class FunctionNotSupported(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(FunctionNotSupported, self).__init__(
-                ("RBD function not supported (%s)" % msg))
+                ("RBD function not supported (%s)" % msg), errno=errno)
 
 
 class ArgumentOutOfRange(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ArgumentOutOfRange, self).__init__(
-                ("RBD arguments out of range (%s)" % msg))
+                ("RBD arguments out of range (%s)" % msg), errno=errno)
 
 
 class ConnectionShutdown(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(ConnectionShutdown, self).__init__(
-                ("RBD connection was shutdown (%s)" % msg))
+                ("RBD connection was shutdown (%s)" % msg), errno=errno)
 
 
 class Timeout(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(Timeout, self).__init__(
-                ("RBD operation timeout (%s)" % msg))
+                ("RBD operation timeout (%s)" % msg), errno=errno)
 
 
 class DiskQuotaExceeded(OSError):
-    def __init__(self, msg):
+    def __init__(self, msg, errno=None):
         super(DiskQuotaExceeded, self).__init__(
-                ("RBD Disk Quota Exceeded (%s)" % msg))
+                ("RBD Disk Quota Exceeded (%s)" % msg), errno=errno)
 
 
 cdef errno_to_exception = {


### PR DESCRIPTION
Commit https://github.com/starlingx-staging/stx-ceph/commit/53e93f was
ported from Jewel to Mimic but was not updated for changes in make_ex()
for the named errno parameter. As a result we are seeing

TypeError: _init_() got an unexpected keyword argument 'errno'

This updates the code accordingly to support this and not raise an
exception.

Signed-off-by: Robert Church <robert.church@windriver.com>