### PR TITLE
LP 1831300 ceph-mgr memory leak on active controller

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -213,7 +213,7 @@ bool DaemonServer::ms_verify_authorizer(
 	is_valid = false;
       }
     }
-    con->set_priv(s->get());
+    con->set_priv(s);
 
     if (peer_type == CEPH_ENTITY_TYPE_OSD) {
       Mutex::Locker l(lock);

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -162,6 +162,7 @@ private:
   Finisher finisher;
 
   bool initialized;
+  bool stopping = false;
   bool no_keyring_disabled_cephx;
 
   LogClient *log_client;


### PR DESCRIPTION
Investigate ceph-mgr RSS memory increase reported by  https://bugs.launchpad.net/starlingx/+bug/1831300
Identified ceph-mgr leak in DaemonServer and this https://github.com/ceph/ceph/pull/14092 upstream discussion around fixing ceph-mgr leaks reported by Valgrind.
Back-ported commits from https://github.com/ceph/ceph/pull/14092/commits applicable to Mimic version. 