### PR TITLE
LP 1830938 rgw: rgwgc:process coredump in some special case

### DIFF
--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -313,6 +313,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
           ctx = new IoCtx;
 	  ret = rgw_init_ioctx(store->get_rados_handle(), obj.pool, *ctx);
 	  if (ret < 0) {
+	    last_pool = "";
 	    dout(0) << "ERROR: failed to create ioctx pool=" << obj.pool << dendl;
 	    continue;
 	  }


### PR DESCRIPTION
Investigate LP: https://bugs.launchpad.net/starlingx/+bug/1830938
This should be the same issue: https://tracker.ceph.com/issues/23199 which has fixed by PR: https://github.com/ceph/ceph/pull/25430, Signed-off-by: zhaokun <develop@hikdata.com>
Backport it to Mimic version.