### PR TITLE
Ensure NVMe journal partition is detected after labeling

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2450,6 +2450,8 @@ class PrepareSpace(object):
             ],
         )
 
+        update_partition(getattr(self.args, self.name), 'prepared')
+
         if self.wipe_device:
             LOG.debug('Erasing partition %s',
                       self.space_symlink)
@@ -2460,8 +2462,6 @@ class PrepareSpace(object):
                     'of=' + self.space_symlink,
                 ],
             )
-
-        update_partition(getattr(self.args, self.name), 'prepared')
 
         LOG.debug('%s is GPT partition %s',
                   self.name.capitalize(),


### PR DESCRIPTION
After labeling the journal partition, call partprobe and wait for udev
to settle to ensure that the udev rules create the proper /dev/disk
symbolic links.

This should be done to ensure that the followup conditional wipe
operation has the proper symbolic link in place so it doesn't
inadvertently attempt to wipe the whole disk.

Closes-Bug: #1913343
Signed-off-by: Robert Church <robert.church@windriver.com>