### PR TITLE
Start Ceph processes in its own systemd slice and scope per process

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -866,6 +866,14 @@ for name in $what; do
 
 	    [ -n "$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES" ] && tcmalloc="TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES"
 
+		# StarlingX: start processes in scope under slice system-ceph.slice
+		# so that ceph processes do not start under this script's callers cgroup
+		if [ "$type" = "osd" ]; then
+			cmd="systemd-run --scope --unit=ceph-${type}-${id} --slice=system-ceph $cmd"
+		else
+			cmd="systemd-run --scope --unit=ceph-${type} --slice=system-ceph $cmd"
+		fi
+
 	    # StarlingX: not running as ceph user/group
 	    cmd="$files $tcmalloc $wrap $cmd --cluster $cluster $runmode"
 


### PR DESCRIPTION
Ceph processes are currently being started under the cgroup of the
init-ceph script callers. This can cause inconsistencies and processes
under different unit services. Also, depending on the unit configuration
the ceph process can be terminated when the unit service is terminated/
restarted, etc.

This commit creates systemd scope for each ceph process under slice
system.slice/ceph.slice in order to provide isolation.

Closes-Bug: https://bugs.launchpad.net/starlingx/+bug/1930631
Signed-off-by: Pedro Henrique Linhares <PedroHenriqueLinhares.Silva@windriver.com>