### PR TITLE
Removing deprecated attribute from rbd_list function

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -336,8 +336,7 @@ CEPH_RBD_API void rbd_linked_image_spec_list_cleanup(
 CEPH_RBD_API void rbd_snap_spec_cleanup(rbd_snap_spec_t *snap);
 
 /* images */
-CEPH_RBD_API int rbd_list(rados_ioctx_t io, char *names, size_t *size)
-    __attribute__((deprecated));
+CEPH_RBD_API int rbd_list(rados_ioctx_t io, char *names, size_t *size);
 CEPH_RBD_API int rbd_list2(rados_ioctx_t io, rbd_image_spec_t* images,
                            size_t *max_images);
 


### PR DESCRIPTION
Currently starlingx does not build when there is code using deprecated
code. The libvirt module calls rbd_list from
virStorageBackendRBDRefreshPool on storage_backend_rbd.c

The code evolved after this bugfix
https://bugzilla.redhat.com/show_bug.cgi?id=1689575 in this commit
https://github.com/libvirt/libvirt/commit/3aa190f2a43a632b542a6ba751a6c3ab4d51f1dd

This solution is intended to be simplest possible so we can focus on
ceph upgrade with minimal effort for now, but in the future other
options are available, as upgrade libvirt version

Signed-off-by: Delfino Curado <delfinogomes.curadofilho@windriver.com>