### PR TITLE
Enable ceph init script to use already mounted osd filesystem

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -918,7 +918,7 @@ for name in $what; do
 		    do_root_cmd_okfail "modprobe btrfs ; btrfs device scan || btrfsctl -a ; egrep -q '^[^ ]+ $fs_path ' /proc/mounts && umount $fs_path ; mount -t btrfs $fs_opt $first_dev $fs_path"
 		else
 		    echo Mounting $fs_type on $host:$fs_path
-		    do_root_cmd_okfail "modprobe $fs_type ; egrep -q '^[^ ]+ $fs_path ' /proc/mounts && umount $fs_path ; mount -t $fs_type $fs_opt $first_dev $fs_path"
+		    do_root_cmd_okfail "modprobe $fs_type ; egrep -q '^[^ ]+ $fs_path ' /proc/mounts && umount $fs_path ; MOUNT_RESULT=\$(mount -t $fs_type $fs_opt $first_dev $fs_path 2>&1); [ \$? == 0 ] || (echo \$MOUNT_RESULT | grep 'already mounted')"
 		fi
 		if [ "$ERR" != "0" ]; then
 		    EXIT_STATUS=$ERR


### PR DESCRIPTION
Ceph initialization script /etc/init.d/ceph was failing to start osd when osd disk is already mounted and the umount fails because disk is in use.

The script line has an umount command that fails if the partition is in use. The, the next mount command will fail returning 32. If the error is that the partition is already mounted, look for 'already mounted' text in the output and then ignore the mount error returning success and continuing the start script.

An example of error text output:
 === osd.0 ===
 Mounting xfs on controller-0:/var/lib/ceph/osd/ceph-0
 umount: /var/lib/ceph/osd/ceph-0: target is busy.
 mount: /var/lib/ceph/osd/ceph-0: /dev/nvme2n1p1 already mounted
   on /var/lib/ceph/osd/ceph-0.
 failed: 'modprobe xfs ; egrep -q '^[^ ]+ /var/lib/ceph/osd/ceph-0 '
   /proc/mounts && umount /var/lib/ceph/osd/ceph-0 ;
   mount -t xfs -o rw,noatime,inode64,logbufs=8,logbsize=256k
   /dev/disk/by-path/pci-0000:11:00.0-nvme-1-part1
   /var/lib/ceph/osd/ceph-0'

Closes-bug: 1999826

Signed-off-by: Felipe Sanches Zanoni <Felipe.SanchesZanoni@windriver.com>