### PR TITLE
Fix ceph-disk output for multipath disks

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -4494,7 +4494,8 @@ def list_format_more_osd_info_plain(dev):
 
 def list_format_dev_plain(dev, prefix=''):
     desc = []
-    if dev['ptype'] == PTYPE['regular']['osd']['ready']:
+    if dev['ptype'] in (PTYPE['regular']['osd']['ready']
+                        PTYPE['mpath']['osd']['ready']):
         desc = (['ceph data', dev['state']] +
                 list_format_more_osd_info_plain(dev))
     elif dev['ptype'] in (PTYPE['regular']['lockbox']['ready'],
@@ -4514,7 +4515,7 @@ def list_format_dev_plain(dev, prefix=''):
         else:
             desc = ['ceph data (dmcrypt %s)' % dmcrypt['type'],
                     'holders: ' + ','.join(dmcrypt['holders'])]
-    elif Ptype.is_regular_space(dev['ptype']):
+    elif Ptype.is_regular_space(dev['ptype']) or Ptype.is_mpath_space(dev['ptype']):
         name = Ptype.space_ptype_to_name(dev['ptype'])
         desc.append('ceph ' + name)
         if dev.get(name + '_for'):


### PR DESCRIPTION
When running ceph-disk on a system whithout multipath disks, the output for Ceph OSD and Journal looks like:

/dev/sdb :
 /dev/sdb1 ceph data, prepared, cluster ceph, osd.0, osd uuid \
      e3c08a72-c755-4dec-b353-e4df4b4690c4, journal /dev/sdb2
 /dev/sdb2 ceph journal, for /dev/sdb1

And when running same command on a system with multipath disks, the output is:

/dev/dm-5 :
 /dev/dm-6 data, xfs, mounted on /var/lib/ceph/osd/ceph-1
 /dev/dm-7 journal, 45b0969e-8ae0-4982-bf9d-5a8d867af560

With this fix, the output looks the same for system with and whithout multipath disks.

This error was preventing the system to identify ceph OSDs were already configured and ODSs were being zapped every host reboot.

Test Plan:
    PASS: Fresh install AIO-SX with multipath disks and
          Ceph backend
    PASS: Run ceph-disk command and verify output for osds

Closes-bug: 2009227