### PR TITLE
Fix missing comma in ceph-disk module

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -4494,7 +4494,7 @@ def list_format_more_osd_info_plain(dev):
 
 def list_format_dev_plain(dev, prefix=''):
     desc = []
-    if dev['ptype'] in (PTYPE['regular']['osd']['ready']
+    if dev['ptype'] in (PTYPE['regular']['osd']['ready'],
                         PTYPE['mpath']['osd']['ready']):
         desc = (['ceph data', dev['state']] +
                 list_format_more_osd_info_plain(dev))


### PR DESCRIPTION
Last commit causes build to fail because of missing comma at the end of a line.

Test Plan:
    PASS: Build ceph package successfully

Closes-bug: 2009731

Signed-off-by: Felipe Sanches Zanoni <Felipe.SanchesZanoni@windriver.com>