### PR TITLE
Fix execute_ceph_cmd function in ceph_common.sh

### DIFF
--- a/src/ceph_common.sh
+++ b/src/ceph_common.sh
@@ -43,12 +43,12 @@ execute_ceph_cmd() {
     eval "$cmd &>$DATA_PATH/.ceph_cmd_out"
     errcode=$?
     set +o pipefail
-    if [ -z "$output" ] && [ $errcode -eq 124 ]; then  # 'timeout' returns 124 when timing out
+    if [ $errcode -eq 124 ]; then  # 'timeout' returns 124 when timing out
         wlog $name "WARN" "Ceph failed to respond in ${WAIT_FOR_CMD}s when running: $cmd"
         CEPH_FAILURE="true"
         echo ""; return 1
     fi
-    output=$(cat $DATA_PATH/.ceph_cmd_out)
+    local output=$(cat $DATA_PATH/.ceph_cmd_out)
     if [ -z "$output" ] || [ $errcode -ne 0 ]; then
         wlog $name "WARN" "Error executing: $cmd errorcode: $errcode output: $output"
         echo ""; return 1


### PR DESCRIPTION
The function execute_ceph_cmd in ceph_common.sh used the 'output' variable as global and was not initialized before the first use. This way, the CEPH_FAILURE variable was not being set as expected.

The 'output' variable is now set as local and the function is fixed to set the CEPH_FAILURE variable accordingly.

Test-Plan:
- PASS: Create a script with 'output' variable set to a random value and
call the execute_ceph_cmd function with 'ceph health detail'
command. Run the script with Ceph running. The CEPH_FAILURE
must be different than 'true' and the 'output' variable must
not change.

- PASS: Execute the same script as above, but with Ceph stopped. The
CEPH_FAILURE variable must be equal 'true' and the 'output'
variable must not change.

Partial-bug: https://bugs.launchpad.net/starlingx/+bug/2083056

Signed-off-by: Felipe Sanches Zanoni <Felipe.SanchesZanoni@windriver.com>