### PR TITLE
Fix execute_ceph_cmd function race condition

### DIFF
--- a/src/ceph_common.sh
+++ b/src/ceph_common.sh
@@ -40,7 +40,7 @@ execute_ceph_cmd() {
     local cmd=$3
     local cmd="timeout $WAIT_FOR_CMD $cmd"
     set -o pipefail
-    eval "$cmd &>$DATA_PATH/.ceph_cmd_out"
+    eval "$cmd &>$DATA_PATH/.ceph_cmd_out_$$"
     errcode=$?
     set +o pipefail
     if [ $errcode -eq 124 ]; then  # 'timeout' returns 124 when timing out
@@ -48,7 +48,8 @@ execute_ceph_cmd() {
         CEPH_FAILURE="true"
         echo ""; return 1
     fi
-    local output=$(cat $DATA_PATH/.ceph_cmd_out)
+    local output=$(cat $DATA_PATH/.ceph_cmd_out_$$)
+    rm -f $DATA_PATH/.ceph_cmd_out_$$
     if [ -z "$output" ] || [ $errcode -ne 0 ]; then
         wlog $name "WARN" "Error executing: $cmd errorcode: $errcode output: $output"
         echo ""; return 1


### PR DESCRIPTION
The function execute_ceph_cmd in ceph_common.sh uses a temporary file to get the command output. It uses the same filename for all the calls. This is not thread-safe and since many processes call this function, a race condition can happen.

The filename now has the PID concatenated at the end. This way the filename will never be the same for processes calling this function simultaneously.

The filename was '.ceph_cmd_out' and has changed to '._ceph_cmd_out_$$', where $$ will be replaced by the PID

Test-Plan:
    PASS: Call the script and check if the file was created using the
          new filename template and it is removed when the function
          returns

Closes-bug: https://bugs.launchpad.net/starlingx/+bug/2085648

Signed-off-by: Felipe Sanches Zanoni <Felipe.SanchesZanoni@windriver.com>